### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,5 +1,8 @@
 name: Django CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Ngaremaina/Products-Django-API/security/code-scanning/1](https://github.com/Ngaremaina/Products-Django-API/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow only reads repository contents (e.g., checking out the code and installing dependencies), the minimal required permission is `contents: read`. This block should be added at the root level of the workflow to apply to all jobs, as none of the jobs require additional permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
